### PR TITLE
Purify nix-shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 with import <nixpkgs> {};
 let
   gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+  boost = boost165;
 in stdenv.mkDerivation rec {
   name = "bitcoin-dev-env";
   src = ./.;

--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@ rec {
       gnumake
       libtool
       m4
+      which
       openssl db48 boost zlib miniupnpc protobuf libevent
       pkgconfig
       utillinux qt4 qrencode

--- a/default.nix
+++ b/default.nix
@@ -1,44 +1,42 @@
 with import <nixpkgs> {};
 let gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc; in
-rec {
-  btc = stdenv.mkDerivation rec {
-    name = "bitcoin-dev-env";
-    src = ./.;
-    version = "0.1.0";
-    AC_PROG_CXX="$(type -p g++)";
-    gppPath = "${gcc}/include/c++/" +
-      builtins.replaceStrings ["gcc-"] [""] gcc.name;
+stdenv.mkDerivation rec {
+  name = "bitcoin-dev-env";
+  src = ./.;
+  version = "0.1.0";
+  AC_PROG_CXX="$(type -p g++)";
+  gppPath = "${gcc}/include/c++/" +
+    builtins.replaceStrings ["gcc-"] [""] gcc.name;
 
-    PKG_PROG_PKG_CONFIG="${pkgs.pkgconfig}/bin/pkg-config";
-    BDB_CFLAGS="${pkgs.db48}/include";
+  PKG_PROG_PKG_CONFIG="${pkgs.pkgconfig}/bin/pkg-config";
+  BDB_CFLAGS="${pkgs.db48}/include";
 
-    BOOST_LIBS="${boost}/lib/";
-    BOOST_ROOT="${boost}";
+  BOOST_LIBS="${boost}/lib/";
+  BOOST_ROOT="${boost}";
 
-    BOOST_LDFLAGS="-L${boost}/lib/";
-    BOOST_CPPFLAGS=
-      "-I${boost.dev}/include/ " +
-      "-L${boost}/lib/ " +
-      "-lboost_system";
+  BOOST_LDFLAGS="-L${boost}/lib/";
+  BOOST_CPPFLAGS=
+    "-I${boost.dev}/include/ " +
+    "-L${boost}/lib/ " +
+    "-lboost_system";
 
-    CPPFLAGS =
-      "-isystem ${gppPath} " +
-      "-isystem ${gppPath}/${stdenv.targetPlatform.config}";
+  CPPFLAGS =
+    "-isystem ${gppPath} " +
+    "-isystem ${gppPath}/${stdenv.targetPlatform.config}";
 
-    buildInputs = [
-      autoconf
-      automake
-      db48
-      glibc
-      gnumake
-      libtool
-      m4
-      which
-      openssl db48 boost zlib miniupnpc protobuf libevent
-      pkgconfig
-      utillinux qt4 qrencode
-    ];
-  };
+  buildInputs = [
+    autoconf
+    automake
+    db48
+    glibc
+    gnumake
+    libtool
+    m4
+    which
+    openssl db48 boost zlib miniupnpc protobuf libevent
+    pkgconfig
+    utillinux qt4 qrencode
+  ];
 
   TERM="ansi";
 }

--- a/default.nix
+++ b/default.nix
@@ -38,5 +38,19 @@ stdenv.mkDerivation rec {
     utillinux qt4 qrencode
   ];
 
-  TERM="ansi";
+  shellHook = ''
+    # https://github.com/NixOS/nix/issues/1056
+    export TERMINFO=/run/current-system/sw/share/terminfo
+    real_TERM=$TERM; TERM=xterm; TERM=$real_TERM; unset real_TERM
+
+    exitstatus() {
+      if [[ $? == 0 ]]; then
+        echo -e "\e[92m"
+      else
+        echo -e "\e[91m"
+      fi
+    }
+    export PS1='\[$(exitstatus)\]Ƀ\[\e[39m\] '
+    export PS2="Ƀ "
+  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -28,13 +28,13 @@ rec {
     buildInputs = [
       autoconf
       automake
-      gnumake
-      glibc
       db48
-      m4
+      glibc
+      gnumake
       libtool
-      pkgconfig
+      m4
       openssl db48 boost zlib miniupnpc protobuf libevent
+      pkgconfig
       utillinux qt4 qrencode
     ];
   };

--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     autoconf
     automake
     db48
+    gcc
     glibc
     gnumake
     libtool

--- a/default.nix
+++ b/default.nix
@@ -1,41 +1,39 @@
 with import <nixpkgs> {};
 let gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc; in
-rec {
-  btc = stdenv.mkDerivation rec {
-    name = "bitcoin-dev-env";
-    src = ./.;
-    version = "0.1.0";
-    AC_PROG_CXX="$(type -p g++)";
-    gppPath = "${gcc}/include/c++/" +
-      builtins.replaceStrings ["gcc-"] [""] gcc.name;
+stdenv.mkDerivation rec {
+  name = "bitcoin-dev-env";
+  src = ./.;
+  version = "0.1.0";
+  AC_PROG_CXX="$(type -p g++)";
+  gppPath = "${gcc}/include/c++/" +
+    builtins.replaceStrings ["gcc-"] [""] gcc.name;
 
-    PKG_PROG_PKG_CONFIG="${pkgs.pkgconfig}/bin/pkg-config";
-    BDB_CFLAGS="-I${pkgs.db48.dev}/include";
+  PKG_PROG_PKG_CONFIG="${pkgs.pkgconfig}/bin/pkg-config";
+  BDB_CFLAGS="-I${pkgs.db48.dev}/include";
 
-    BOOST_LIBS="${boost}/lib/";
-    BOOST_ROOT="${boost}";
+  BOOST_LIBS="${boost}/lib/";
+  BOOST_ROOT="${boost}";
 
-    BOOST_LDFLAGS="-L${boost}/lib/";
-    BOOST_CPPFLAGS=
-      "-I${boost.dev}/include/ " +
-      "-L${boost}/lib/ " +
-      "-lboost_system";
+  BOOST_LDFLAGS="-L${boost}/lib/";
+  BOOST_CPPFLAGS=
+    "-I${boost.dev}/include/ " +
+    "-L${boost}/lib/ " +
+    "-lboost_system";
 
-    CPPFLAGS =
-      "-isystem ${gppPath} " +
-      "-isystem ${gppPath}/${stdenv.targetPlatform.config}";
+  CPPFLAGS =
+    "-isystem ${gppPath} " +
+    "-isystem ${gppPath}/${stdenv.targetPlatform.config}";
 
-    buildInputs = [
-      autoconf
-      automake
-      gnumake
-      glibc
-      python3
-      m4
-      libtool
-      pkgconfig
-      openssl db48 boost zlib miniupnpc protobuf libevent
-      utillinux qt4 qrencode
-    ];
-  };
+  buildInputs = [
+    autoconf
+    automake
+    gnumake
+    glibc
+    python3
+    m4
+    libtool
+    pkgconfig
+    openssl db48 boost zlib miniupnpc protobuf libevent
+    utillinux qt4 qrencode
+  ];
 }

--- a/default.nix
+++ b/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
         echo -e "\e[91m"
       fi
     }
-    export PS1='\[$(exitstatus)\]Ƀ\[\e[39m\] '
-    export PS2="Ƀ "
+    export PS1='\n\[$(exitstatus)\]Ƀ\[\e[39m\] '
+    export PS2="\nɃ "
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 with import <nixpkgs> {};
-let gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc; in
-stdenv.mkDerivation rec {
+let
+  gcc = if stdenv.cc.isGNU then stdenv.cc.cc else stdenv.cc.cc.gcc;
+in stdenv.mkDerivation rec {
   name = "bitcoin-dev-env";
   src = ./.;
   version = "0.1.0";
@@ -27,16 +28,24 @@ stdenv.mkDerivation rec {
   buildInputs = [
     autoconf
     automake
+    boost
+    db48
     gcc
     glibc
     gnumake
+    libevent
     libtool
     m4
-    openssl db48 boost zlib miniupnpc protobuf libevent
+    miniupnpc
+    openssl
     pkgconfig
+    protobuf
     python3
-    utillinux qt4 qrencode
+    qrencode
+    qt4
+    utillinux
     which
+    zlib
   ];
 
   shellHook = ''

--- a/default.nix
+++ b/default.nix
@@ -38,4 +38,6 @@ rec {
       utillinux qt4 qrencode
     ];
   };
+
+  TERM="ansi";
 }


### PR DESCRIPTION
 - Update to function in pure shell (i.e.: `nix-shell --pure`).
 - Pin boost to v1.6.5 to deal with `error: no match for call to '(const key_compare {aka const CompareModifiedEntry}) (const CTxMemPoolModifiedEntry&, CTxMemPoolModifiedEntry&)` as covered in PR's [Bitcoin-ABC/bitcoin-abc #173](https://github.com/Bitcoin-ABC/bitcoin-abc/issues/173) and [bitcoin/bitcoin #12116](https://github.com/bitcoin/bitcoin/issues/12116).
 - Shorten shell prompt and set color based on error status of the previous command

**DISCLAIMER**: On my setup, I'm still building against bitcoin/bitcoin `57ee73990f1ce29916adfd99f93eae1ccea1a43b` :scream: (I haven't yet pulled the latest change to work on this nix-shell update)