### PR TITLE
docker: boost program options are no longer required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN \
     libboost-system-dev \
     libboost-filesystem-dev \
     libboost-chrono-dev \
-    libboost-program-options-dev \
     libboost-test-dev \
     libboost-thread-dev \
     libdb4.8-dev \


### PR DESCRIPTION
Boost Program Options is no longer a requirement to build Bitcoin Core.